### PR TITLE
Avoid modifying actual array length

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -106,7 +106,7 @@
   function addPost (postUrl, callback) {
 
     posts.push({
-      id: ++posts.length,
+      id: posts.length + 1,
       url: postUrl
     })
     setTimeout(() => {


### PR DESCRIPTION
Fixed array bug on server side as it was incrementing posts and adding a null as the array got bigger.